### PR TITLE
Use `.npmrc` to ingest token from env vars for auth to fontawesome

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Don't accidentally commit our token for npm access - or the pro icons themselves - to the pro icons
-.npmrc
 node_modules
 
 # The directory Mix will write compiled artifacts to.

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@fortawesome:registry=https://npm.fontawesome.com/
+//npm.fontawesome.com/:_authToken=${FONTAWESOME_NPM_AUTH_TOKEN}


### PR DESCRIPTION
Hi there! I tried using the installation instructions in your readme but I got the following error:

```
$ FONTAWESOME_NPM_AUTH_TOKEN=<token_snipped> EX_FONTAWESOME_PRO=deps/ex_fontawesome_pro mix ex_fontawesome_pro
npm ERR! code E401
npm ERR! Incorrect or missing password.
npm ERR! If you were trying to login, change your password, create an
npm ERR! authentication token or enable two-factor authentication then
npm ERR! that means you likely typed your password in incorrectly.
npm ERR! Please try again, or recover your password at:
npm ERR!     https://www.npmjs.com/forgot
npm ERR! 
npm ERR! If you were doing some other operation then your saved credentials are
npm ERR! probably out of date. To correct this please try logging in again with:
npm ERR!     npm login

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/jmill/.npm/_logs/2023-08-09T14_46_09_022Z-debug-0.log
```

Inspecting the log file showed this line:
```
HttpErrorAuthUnknown: Unable to authenticate, need: Basic realm="https://npm.fontawesome.com/",service="npm.fontawesome.com"
```

The FontAwesome [docs](https://fontawesome.com/docs/web/setup/packages#alternate-per-project-setup-using-environment-variables) suggest adding an `.npmrc` to specify an authtoken for a given project. It seemed like the per-project settings were the best fit in this case.

Adding this to a `.npmrc` fixed the problem (and instructs it to use an env var), so I removed it as an ignored file in `.gitignore` because I think this still addresses your concerns about accidentally committing the token.

That said, I might be missing some context -- thanks for a cool library!